### PR TITLE
lower minSdkVersion

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -8,7 +8,7 @@ android {
 
 
     defaultConfig {
-        minSdkVersion 26
+        minSdkVersion 21
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
Lower library's minimum sdk version to 21-22 so can actually support devs who want to use it. Noone wants to add a library in his app which is applicable in only a small ammount of phones.